### PR TITLE
update Falco project details

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,14 +1,14 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/falco/horizontal/color/falco-horizontal-color.svg?sanitize=true"
   display_name: Falco
-  sub_title: Container Native Runtime Security
+  sub_title: Container Security
   project_url: "https://github.com/falcosecurity/falco"
   stable_ref: "v0.18.0"
   head_ref: "master"
   ci_system:
     -
       ci_system_type: "travis-ci"
-      ci_project_url: "https://example.com/falcosecurity/falco"  # can be anything for citest
+      ci_project_url: "https://travis-ci.com/falcosecurity/falco" 
       ci_project_name: "falcosecurity/falco"
       arch:
         - amd64


### PR DESCRIPTION
## Description
1. The cncf.ci dashboard currently supports Graduated and Incubating projects. After Falco is approved as an Incubating level project, Falco may be displayed on cncf.ci. 

2. Update Falco project details 
   a. Change subtitle to match wording on https://www.cncf.io/sandbox-projects/ (subtitle on cncf.ci is limited to 21 characters)
   b. Change ci_project_url from `example.com` to https://travis-ci.com/falcosecurity/falco

## Issues:
- https://github.com/crosscloudci/crosscloudci/issues/214

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Browser tested on staging.cncf.ci
* [x]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.


